### PR TITLE
RAS-867 Migrate EQ Mock from GCR to GAR in ons-ci-rmrasbs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   IMAGE: mock-eq
-  REGISTRY_HOSTNAME: eu.gcr.io
-  HOST: ras-rm-sandbox #TODO change for when done with sandbox
+  REGISTRY_HOSTNAME: europe-west2-docker.pkg.dev
+  HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
   GAR_REPOSITORY: ras-rm-docker-repo #TODO add to secrets
   RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
   CHART_DIRECTORY: _infra/helm/mock-eq
@@ -60,11 +60,11 @@ jobs:
       - name: Build Docker Image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ steps.tag.outputs.pr_number }} -f _infra/docker/Dockerfile .
+          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ steps.tag.outputs.pr_number }} -f _infra/docker/Dockerfile .
       - name: Push dev image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker push "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ steps.tag.outputs.pr_number }}
+          docker push "$REGISTRY_HOSTNAME"/"$HOST"/"GAR_$REPOSITORY"/"$IMAGE":${{ steps.tag.outputs.pr_number }}
       - name: template helm
         run: |
           helm template $CHART_DIRECTORY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ env:
   IMAGE: mock-eq
   REGISTRY_HOSTNAME: europe-west2-docker.pkg.dev
   HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
-  GAR_REPOSITORY: images #TODO add to secrets
+  GAR_REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
   RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
   CHART_DIRECTORY: _infra/helm/mock-eq
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ env:
   IMAGE: mock-eq
   REGISTRY_HOSTNAME: europe-west2-docker.pkg.dev
   HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
-  GAR_REPOSITORY: ras-rm-docker-repo #TODO add to secrets
+  GAR_REPOSITORY: images #TODO add to secrets
   RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
   CHART_DIRECTORY: _infra/helm/mock-eq
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west2-docker.pkg.dev
 
       - name: pr docker tag
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - run: |
-          gcloud info
           gcloud auth configure-docker europe-west2-docker.pkg.dev
 
       - name: pr docker tag

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Push dev image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker push "$REGISTRY_HOSTNAME"/"$HOST"/"GAR_$REPOSITORY"/"$IMAGE":${{ steps.tag.outputs.pr_number }}
+          docker push "$REGISTRY_HOSTNAME"/"$HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ steps.tag.outputs.pr_number }}
       - name: template helm
         run: |
           helm template $CHART_DIRECTORY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - run: |
+          gcloud info
           gcloud auth configure-docker europe-west2-docker.pkg.dev
 
       - name: pr docker tag

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,8 @@ on:
 env:
   IMAGE: mock-eq
   REGISTRY_HOSTNAME: eu.gcr.io
-  HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
+  HOST: ras-rm-sandbox #TODO change for when done with sandbox
+  GAR_REPOSITORY: ras-rm-docker-repo #TODO add to secrets
   RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
   CHART_DIRECTORY: _infra/helm/mock-eq
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}

--- a/_infra/helm/mock-eq/values.yaml
+++ b/_infra/helm/mock-eq/values.yaml
@@ -6,9 +6,9 @@ gcp:
   topic: sdx-receipt-dev
 
 image:
-  devRepo: europe-west2-docker.pkg.dev/ras-rm-management/images
-  name: europe-west2-docker.pkg.dev/ras-rm-management/images
-  tag: latest
+  devRepo: europe-west2-docker.pkg.dev/ons-rasrmbs-management/images
+  name: europe-west2-docker.pkg.dev/ons-rasrmbs-management/images
+  tag: pr-26
   pullPolicy: Always
 
 resources:

--- a/_infra/helm/mock-eq/values.yaml
+++ b/_infra/helm/mock-eq/values.yaml
@@ -6,8 +6,8 @@ gcp:
   topic: sdx-receipt-dev
 
 image:
-  devRepo: eu.gcr.io/ons-rasrmbs-management
-  name: eu.gcr.io/ons-rasrmbs-management
+  devRepo: europe-west2-docker.pkg.dev/ras-rm-sandbox/ras-rm-docker-repo
+  name: europe-west2-docker.pkg.dev/ras-rm-sandbox/ras-rm-docker-repo
   tag: latest
   pullPolicy: Always
 

--- a/_infra/helm/mock-eq/values.yaml
+++ b/_infra/helm/mock-eq/values.yaml
@@ -6,8 +6,8 @@ gcp:
   topic: sdx-receipt-dev
 
 image:
-  devRepo: europe-west2-docker.pkg.dev/ras-rm-sandbox/ras-rm-docker-repo
-  name: europe-west2-docker.pkg.dev/ras-rm-sandbox/ras-rm-docker-repo
+  devRepo: europe-west2-docker.pkg.dev/ras-rm-management/images
+  name: europe-west2-docker.pkg.dev/ras-rm-management/images
   tag: latest
   pullPolicy: Always
 


### PR DESCRIPTION
# What and why?
This PR updates the Github actions and helm chart yaml files to point at GAR instead of GCR
# How to test?
- Create sandbox environment and deploy your namespace
- Update `gcr-secret` through the `deploy-config` step in concourse using the https://github.com/ONSdigital/ras-rm-terraform/pull/330 PR
- Deploy `mock-eq` through spinnaker (or deploying via helm) after updating some fields
   - `Helm values config key` to `image.devRepo`
   - `Helm values config value` to `europe-west2-docker.pkg.dev/ons-rasrmbs-management/images`
   - `docker image tag*` to `pr-26`
- Ensure `mock-eq` deploys fine
# Jira
[RAS-872](https://jira.ons.gov.uk/browse/RAS-872)