### PR TITLE
Write out JWT code block in v3 template

### DIFF
--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
 
-version: 1.0.20
+version: 1.0.21
 
-appVersion: 1.0.20
+appVersion: 1.0.21

--- a/mock_eq/templates/mock_eq.html
+++ b/mock_eq/templates/mock_eq.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div>
   <h1>Welcome to the Mock eQ App!</h1>
-  <a id="completeEq" href="{{ url_for('receipt') }}?token={{ payload }}">Compete eQ Survey and Return to Frontstage</a>
+  <a id="completeEq" href="{{ url_for('receipt') }}?token={{ token }}">Compete eQ Survey and Return to Frontstage</a>
   <p></p>
   <a id="returnLink" href="{{ frontstage }}">Return to Frontstage</a>
 </div>

--- a/mock_eq/templates/mock_eq_v3.html
+++ b/mock_eq/templates/mock_eq_v3.html
@@ -9,9 +9,14 @@
   <p></p>
   <a id="returnLink" href="{{ frontstage }}">Return to Frontstage</a>
   <p></p>
-  <pre>
-    <code style="white-space: pre-wrap; background-color: #eee; border: 1px solid #999; display: block; padding: 20px;">{{ json_payload }}</code>
-  </pre>
+  {% if (decryptToken) and (json_payload is not none) %}
+    <pre>
+      <code style="white-space: pre-wrap; background-color: #eee; border: 1px solid #999; display: block; padding: 20px;">{{ json_payload }}</code>
+    </pre>
+  {% else %}
+      <a id="decryptToken" href="{{ url_for(request.endpoint) }}?decryptToken=True&token={{ token }}">Decrypt JWT</a>
+  <p></p>
+  {% endif %}
 </div>
 
 {% endblock content %}

--- a/mock_eq/templates/mock_eq_v3.html
+++ b/mock_eq/templates/mock_eq_v3.html
@@ -5,9 +5,13 @@
 {% block content %}
 <div>
   <h1>Welcome to the Mock eQ v3 App!</h1>
-  <a id="completeEq" href="{{ url_for('receipt') }}?token={{ payload }}">Compete eQ v3 Survey and Return to Frontstage</a>
+  <a id="completeEq" href="{{ url_for('receipt') }}?token={{ token }}">Compete eQ v3 Survey and Return to Frontstage</a>
   <p></p>
   <a id="returnLink" href="{{ frontstage }}">Return to Frontstage</a>
+  <p></p>
+  <pre>
+    <code style="white-space: pre-wrap; background-color: #eee; border: 1px solid #999; display: block; padding: 20px;">{{ json_payload }}</code>
+  </pre>
 </div>
 
 {% endblock content %}


### PR DESCRIPTION
# What and why?

To help with simple sanity testing this adds a code block containing the decrypted JWT to the v3 template.

I was intermittently seeing issues with the length of time the token takes to decrypt. However, this hasn't been introduced by this PR and is true of the existing mock-eq 'Receipt and return to frontstage' feature.

As such, I've added a link and query string parameter to choose to "Decrypt the JWT" rather than always doing it by default. That way if there are underlying performance issues it won't impact any existing tests or automation that uses Mock EQ.

# How to test

When a v3 EQ is launched does the page show the decrypted JWT payload in a nice format?

Due to an issue with Spinnaker the mock-eq app may not deploy this branch version (it doesn't artefact match the correct PR Helm chart name) so if `/deploy` doesn't work use the following from this branch locally. Ensure your kube-context is set to the dev cluster.

```
helm uninstall mock-eq --namespace <NAMESPACE>
kubectl delete deployment mock-eq --namespace <NAMESPACE>
kubectl delete externalsecret mock-eq --namespace <NAMESPACE>
kubectl delete service mock-eq --namespace <NAMESPACE>
cd <YOUR_PATH>/ras-rm-mock-eq
helm upgrade --install mock-eq _infra/helm/mock-eq \
	--namespace <NAMESPACE> \
	--set-string gcp.topic="sdx-receipt-<NAMESPACE>" \
	--set-string gcp.project="ras-rm-dev" \
	--set-string env="dev" \
        --set-string namespace="<NAMESPACE>" \
        --set-string image.tag="pr-28"
```
