### PR TITLE
RAS-641: Dev cluster scaling warnings in Kubernetes

### DIFF
--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
 
-version: 1.0.19
+version: 1.0.20
 
-appVersion: 1.0.19
+appVersion: 1.0.20

--- a/_infra/helm/mock-eq/templates/deployment.yaml
+++ b/_infra/helm/mock-eq/templates/deployment.yaml
@@ -10,6 +10,8 @@ spec:
       app: {{ .Chart.Name }}
   template:
     metadata:
+      annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
       labels:
         app: {{ .Chart.Name }}
     spec:


### PR DESCRIPTION
# What and why?
Scaling warnings have been prevalent in the dev cluster and need to be looked at. These need to be fixed or silenced. This PR has a potential fix to the scale down error. However, replication of the original issues has still not been achieved.

# How to test?
TBC

# Jira
https://jira.ons.gov.uk/browse/RAS-641