### PR TITLE
RAS-992: Mock-EQ Replace unmaintained actions/create-release

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
       - uses: onsdigital/ras-rm-spinnaker-action@main

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
       - uses: onsdigital/ras-rm-spinnaker-action@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           gcloud auth configure-docker europe-west2-docker.pkg.dev
 
       - name: pr docker tag
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         id: tag
         run: |
           PR=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
@@ -58,24 +58,24 @@ jobs:
           echo "pr_number=pr-$PR" >> $GITHUB_ENV
         # Build the Docker image
       - name: Build Docker Image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         run: |
           docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }} -f _infra/docker/Dockerfile .
       - name: Push dev image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }}
       - name: template helm
         run: |
           helm template $CHART_DIRECTORY
       - name: Set current tag
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         id: vars
         run: |
           git fetch --tags
           echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
       - name: update versions
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           COMMIT_MSG: |
@@ -128,7 +128,7 @@ jobs:
           fi
 
       - name: output new version
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         id: release
         shell: bash
         run: |
@@ -141,29 +141,29 @@ jobs:
           helm package $CHART_DIRECTORY
 
       - name: Publish dev Chart
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         run: |
           mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-${{ env.pr_number }}.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Build Release Image
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }} .
       - name: Push Release image
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }}
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest
 
       - name: Publish Charts
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Publish Release
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create ${{ env.version }} --title ${{ env.version }} --notes ${{ env.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,7 +157,7 @@ jobs:
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest
 
       - name: Publish Charts
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         run: |
           cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,17 +147,17 @@ jobs:
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Build Release Image
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }} .
       - name: Push Release image
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }}
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest
 
       - name: Publish Charts
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,11 +147,11 @@ jobs:
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Build Release Image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         run: |
           docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }} .
       - name: Push Release image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }}
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest
@@ -163,7 +163,7 @@ jobs:
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Publish Release
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create ${{ env.version }} --verify-tag --title ${{ env.version }} --notes ${{ env.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - run: |
           gcloud auth configure-docker europe-west2-docker.pkg.dev
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build & Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
           token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build & Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           token: ${{ secrets.BOT_TOKEN }}
@@ -167,20 +167,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create ${{ env.version }} --verify-tag --title ${{ env.version }} --notes ${{ env.version }}
-
-#      - uses: actions/create-release@v1
-#        if: github.ref == 'refs/heads/main'
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          tag_name: ${{ env.version }}
-#          release_name: ${{ env.version }}
-#          body: |
-#            Automated release
-#            ${{ env.version }}
-#          draft: false
-#          prerelease: false
-
 
       - name: CD hook
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           gcloud auth configure-docker europe-west2-docker.pkg.dev
 
       - name: pr docker tag
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         id: tag
         run: |
           PR=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
@@ -58,24 +58,24 @@ jobs:
           echo "pr_number=pr-$PR" >> $GITHUB_ENV
         # Build the Docker image
       - name: Build Docker Image
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }} -f _infra/docker/Dockerfile .
       - name: Push dev image
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }}
       - name: template helm
         run: |
           helm template $CHART_DIRECTORY
       - name: Set current tag
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         id: vars
         run: |
           git fetch --tags
           echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
       - name: update versions
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           COMMIT_MSG: |
@@ -128,7 +128,7 @@ jobs:
           fi
 
       - name: output new version
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         id: release
         shell: bash
         run: |
@@ -141,32 +141,32 @@ jobs:
           helm package $CHART_DIRECTORY
 
       - name: Publish dev Chart
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-${{ env.pr_number }}.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Build Release Image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         run: |
           docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }} .
       - name: Push Release image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }}
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":latest
 
       - name: Publish Charts
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         run: |
           cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Publish Release
-        if: github.ref == 'refs/heads/main'
+        if: github.ref != 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create ${{ env.version }} --title ${{ env.version }} --notes ${{ env.version }}
+        run: gh release create ${{ env.version }} --verify-tag --title ${{ env.version }} --notes ${{ env.version }}
 
       - name: CD hook
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create ${{ env.version }} --verify-tag --title ${{ env.version }} --notes ${{ env.version }}
+        run: gh release create ${{ env.version }} --title ${{ env.version }} --notes ${{ env.version }}
 
       - name: CD hook
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,18 +162,25 @@ jobs:
           cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
-      - uses: actions/create-release@v1
+      - name: Publish Release
         if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.version }}
-          release_name: ${{ env.version }}
-          body: |
-            Automated release
-            ${{ env.version }}
-          draft: false
-          prerelease: false
+        run: gh release create ${{ env.version }} --verify-tag --title ${{ env.version }} --notes ${{ env.version }}
+
+#      - uses: actions/create-release@v1
+#        if: github.ref == 'refs/heads/main'
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          tag_name: ${{ env.version }}
+#          release_name: ${{ env.version }}
+#          body: |
+#            Automated release
+#            ${{ env.version }}
+#          draft: false
+#          prerelease: false
+
 
       - name: CD hook
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,10 +163,10 @@ jobs:
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Publish Release
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create ${{ env.version }} --verify-tag --title ${{ env.version }} --notes ${{ env.version }}
+        run: gh release create ${{ env.version }} --title ${{ env.version }} --notes ${{ env.version }}
 
       - name: CD hook
         if: github.ref == 'refs/heads/main'

--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
 
-version: 1.0.22
+version: 1.0.23
 
-appVersion: 1.0.22
+appVersion: 1.0.23


### PR DESCRIPTION
# What and why?
Our current  'actions/create-release' is no longer supported and hasn't been updated sine 2021. We need to migrate to a supported package. There are also deprecation warnings which need to be resolved. This PR achieves this.

# How to test?
Check that the build log (https://github.com/ONSdigital/ras-rm-mock-eq/actions/runs/7526721069/job/20485429203) builds correctly and no longer alerts us to deprecation warnings. The image 1.0.22 was successfully created.

# Jira
https://jira.ons.gov.uk/browse/RAS-992