### PR TITLE
RAS-914 Migrate Mock eq v2 from management to CI project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,11 +60,11 @@ jobs:
       - name: Build Docker Image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }} -f _infra/docker/Dockerfile .
+          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }} -f _infra/docker/Dockerfile .
       - name: Push dev image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker push "$REGISTRY_HOSTNAME"/"$HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }}
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }}
       - name: template helm
         run: |
           helm template $CHART_DIRECTORY

--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
 
-version: 1.0.23
+version: 1.0.24
 
-appVersion: 1.0.23
+appVersion: 1.0.24

--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
 
-version: 1.0.24
+version: 1.0.25
 
-appVersion: 1.0.24
+appVersion: 1.0.25

--- a/_infra/helm/mock-eq/values.yaml
+++ b/_infra/helm/mock-eq/values.yaml
@@ -6,8 +6,8 @@ gcp:
   topic: sdx-receipt-dev
 
 image:
-  devRepo: europe-west2-docker.pkg.dev/ons-rasrmbs-management/images
-  name: europe-west2-docker.pkg.dev/ons-rasrmbs-management/images
+  devRepo: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images
+  name: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images
   tag: latest
   pullPolicy: Always
 


### PR DESCRIPTION
(Card description written by anwilkie)

# What and why?
The image for this repo needed to start being pushed to the `ons-ci-rmrasbs` project instead of the `ons-rasrmbs-management`. This PR makes that changes, as well as a slight edit to the Github Actions build file to ensure that the image is being built with the correct project. Previously, the `$GOOGLE_PROJECT_ID` secret was used when building the image, which was fine when this corresponds to the management project, and was also being used for `$RELEASE_PROJECT`. However, now that these two secrets have different values, the variable calls had to be updated to use the $RELEASE_PROJECT` secret when building the image.

# How to test?
Deploy and test the service. Also, look at [here](https://console.cloud.google.com/artifacts/docker/ons-ci-rmrasbs/europe-west2/images/mock-eq?project=ons-ci-rmrasbs) and verify that the image has been built in the CI project.

# Jira
[Card](https://jira.ons.gov.uk/browse/RAS-914)
