### PR TITLE
Add payload to UI v3 template

### DIFF
--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
 
-version: 1.0.21
+version: 1.0.24
 
-appVersion: 1.0.21
+appVersion: 1.0.24

--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
 
-version: 1.0.23
+version: 1.0.24
 
-appVersion: 1.0.23
+appVersion: 1.0.24

--- a/mock_eq/routes.py
+++ b/mock_eq/routes.py
@@ -1,8 +1,9 @@
-from flask import render_template, request, redirect, flash, jsonify
+from flask import render_template, request, redirect, flash, jsonify, url_for
 from mock_eq import app
 
 from mock_eq.common.decrypter import Decrypter
 from mock_eq.common.pubsub import PubSub
+from sdc.crypto.exceptions import InvalidTokenException, CryptoError
 
 import logging
 import structlog
@@ -22,40 +23,46 @@ def mock_eq():
 
 @app.route("/v3/session", methods=["GET"])
 def mock_eq_v3():
-    # A similar endpoint to represent the EQ v3 site that now exists.  When it comes to the decryption in the /receipt
-    # endpoint, the token should have the kid of key it needs to use.  If the keys have been set up correctly, it should
-    # work for both eq and eq v3 without us having to do anything.
-    payload = request.args.get("token", None)
-    if payload is None:
-        logger.error("No payload passed from frontstage")
-        flash("No payload passed from frontstage")
+    if not (token:= request.args.get("token")):
+        logger.error("No token passed")
+        return render_template("errors/400-error.html", frontstage=app.config["FRONTSTAGE_URL"])
+
+    try:
+        decrypter = Decrypter(app.config["JSON_SECRET_KEYS"])
+        payload = decrypter.decrypt(token)
+    except (InvalidTokenException, CryptoError) as e:
+        logger.error("An error happened when decrypting the token", error=e.value)
+        return render_template("errors/400-error.html", frontstage=app.config["FRONTSTAGE_URL"])
+
+    data = payload["survey_metadata"]["data"]
+
+    receipt_url = url_for(
+        "receipt",
+        case_ref=data["case_ref"],
+        case_id=payload["case_id"],
+        party_id=data["user_id"],
+        sds_dataset_id=data.get("sds_dataset_id"),
+    )
+
     return render_template(
-        "mock_eq_v3.html", title="Mock eQ v3", frontstage=app.config["FRONTSTAGE_URL"], payload=payload
+        "mock_eq_v3.html",
+        title="Mock eQ v3",
+        frontstage=app.config["FRONTSTAGE_URL"],
+        receipt_url=receipt_url,
+        payload=payload,
     )
 
 
 @app.route("/receipt", methods=["GET"])
 def receipt():
-    payload = request.args.get("token", None)
-
-    try:
-        json_secret_keys = app.config["JSON_SECRET_KEYS"]
-        decrypter = Decrypter(json_secret_keys)
-
-        json_payload = decrypter.decrypt(payload)
-        pubsub_payload = {
-            "caseRef": json_payload["survey_metadata"]["data"]["case_ref"],
-            "caseId": json_payload["case_id"],
-            "inboundChannel": "OFFLINE",
-            "partyId": json_payload["survey_metadata"]["data"]["user_id"]
-        }
-
-        if "sds_dataset_id" in json_payload["survey_metadata"]["data"]:
-            pubsub_payload["sdsDatasetId"] = json_payload["survey_metadata"]["data"]["sds_dataset_id"]
-
-    except Exception:
-        logger.error("An error happened when decrypting the frontstage payload", exc_info=True)
-        return render_template("errors/500-error.html", frontstage=app.config["FRONTSTAGE_URL"])
+    pubsub_payload = {
+        "caseRef": request.args.get("case_ref"),
+        "caseId": request.args.get("case_id"),
+        "inboundChannel": "OFFLINE",
+        "partyId": request.args.get("party_id"),
+    }
+    if request.args.get("sds_dataset_id"):
+        pubsub_payload["sdsDatasetId"] = request.args.get("sds_dataset_id")
 
     publisher = PubSub(app.config)
     publisher.publish(pubsub_payload)

--- a/mock_eq/routes.py
+++ b/mock_eq/routes.py
@@ -23,7 +23,7 @@ def mock_eq():
 
 @app.route("/v3/session", methods=["GET"])
 def mock_eq_v3():
-    if not (token:= request.args.get("token")):
+    if not (token := request.args.get("token")):
         logger.error("No token passed")
         return render_template("errors/400-error.html", frontstage=app.config["FRONTSTAGE_URL"])
 

--- a/mock_eq/templates/errors/400-error.html
+++ b/mock_eq/templates/errors/400-error.html
@@ -4,6 +4,6 @@
 
 {% block main %}
     <h1 class="u-fs-xl">An error has occurred</h1>
-    <p>Sorry, something has gone wrong.</p>
+    <p>Bad Request: The server couldn’t resolve the request because of invalid syntax</p>
     <p><a href="{{ frontstage }}">Return to frontstage</a>.</p>
 {% endblock main %}

--- a/mock_eq/templates/mock_eq_v3.html
+++ b/mock_eq/templates/mock_eq_v3.html
@@ -5,9 +5,12 @@
 {% block content %}
 <div>
   <h1>Welcome to the Mock eQ v3 App!</h1>
-  <a id="completeEq" href="{{ url_for('receipt') }}?token={{ payload }}">Compete eQ v3 Survey and Return to Frontstage</a>
+  <a id="completeEq" href="{{ receipt_url }}">Compete eQ v3 Survey and Return to Frontstage</a>
   <p></p>
   <a id="returnLink" href="{{ frontstage }}">Return to Frontstage</a>
+  </br></br>
+  <h3>Payload</h3>
+  <p>{{ payload }}</p>
 </div>
 
 {% endblock content %}


### PR DESCRIPTION
# What and why?
The PR adds the payload to the UI v3 template. Please note I have moved the decryption stage forward and taken it out of the receipt step to avoid having to decrypt twice

N.B as discussed in stand-up there are no tests. This is because the whole repo has no tests and the create_app step would need changing. I have raised a card in tech to create a test suite

# How to test?
Deploy this app to GCP and test that you get the decrypted payload in UI.  If you want to test it locally with frontstage on GCP you will need to update test_key.json as they won't align, you can find the correct values in secret manager
# Jira
