### PR TITLE
chart version bump

### DIFF
--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
 
-version: 1.0.29
+version: 1.0.30
 
-appVersion: 1.0.29
+appVersion: 1.0.30


### PR DESCRIPTION
# What and why?
The build for my previous PR failed because the chart version hadn't been updated.