### PR TITLE
Add dev ip and dns

### DIFF
--- a/_infra/helm/mock-eq/templates/ManagedCertificate.yaml
+++ b/_infra/helm/mock-eq/templates/ManagedCertificate.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{ .Values.ingress.certNameMockEq }}
+spec:
+  domains:
+    - {{ .Values.ingress.mockEqHost }}
+{{- end }}

--- a/_infra/helm/mock-eq/templates/frontendconfig.yaml
+++ b/_infra/helm/mock-eq/templates/frontendconfig.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ .Values.ingress.frontendConfigName }}
+spec:
+  sslPolicy: {{ .Values.frontendConfig.sslPolicy }}
+{{- end }}

--- a/_infra/helm/mock-eq/templates/ingress.yaml
+++ b/_infra/helm/mock-eq/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: mock-eq-ip
     kubernetes.io/ingress.class: gce
-    networking.gke.io/managed-certificates: {{ .Values.ingress.mockEqHost }}
+    networking.gke.io/managed-certificates: {{ .Values.ingress.certNameMockEq }}
     networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfigName }}
 
 spec:

--- a/_infra/helm/mock-eq/templates/ingress.yaml
+++ b/_infra/helm/mock-eq/templates/ingress.yaml
@@ -4,9 +4,9 @@ kind: Ingress
 metadata:
   name: {{ .Chart.Name }}-ingress
   annotations:
-    kubernetes.io/ingress.global-static-ip-name: frontstage-ip
+    kubernetes.io/ingress.global-static-ip-name: mock-eq-ip
     kubernetes.io/ingress.class: gce
-    networking.gke.io/managed-certificates: {{ .Values.ingress.certNameSurveys }}
+    networking.gke.io/managed-certificates: {{ .Values.ingress.mockEqHost }}
     networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfigName }}
 
 spec:

--- a/_infra/helm/mock-eq/templates/ingress.yaml
+++ b/_infra/helm/mock-eq/templates/ingress.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Chart.Name }}-ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: frontstage-ip
+    kubernetes.io/ingress.class: gce
+    networking.gke.io/managed-certificates: {{ .Values.ingress.certNameSurveys }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfigName }}
+
+spec:
+  rules:
+  - host: {{ .Values.ingress.host | quote }}
+    http:
+      paths:
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ .Chart.Name }}
+            port:
+              number: {{ .Values.service.port }}
+{{- end }}

--- a/_infra/helm/mock-eq/values.yaml
+++ b/_infra/helm/mock-eq/values.yaml
@@ -11,6 +11,16 @@ image:
   tag: latest
   pullPolicy: Always
 
+frontendConfig:
+  sslPolicy: mock-eq-ingress-ssl-policy
+
+ingress:
+  enabled: false
+  mockEqHost: mock-eq.example.com
+  certNameMockEq: mock-eq-cert
+  frontendConfigName: mock-eq-frontend-config
+  timeoutSec: 30
+
 resources:
   limits:
     cpu: "100m"


### PR DESCRIPTION
# What and why?

Introduces Kubernetes objects to allow an Ingress, Frontend Config and Managed Certificate into dev.