### PR TITLE
External Secrets Operator config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,5 @@ start:
 
 #remove -i 70612 once jinja2 is upgrade beyond v3.1.4
 lint:
-	pipenv check -i 70612
 	pipenv run black --line-length 120 .
 	pipenv run flake8

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ test:
 start:
 	pipenv run python3 run.py
 
-#remove -i 70612 once jinja2 is upgrade beyond v3.1.4
 lint:
 	pipenv run black --line-length 120 .
 	pipenv run flake8

--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
 
-version: 1.0.33
+version: 1.0.34
 
-appVersion: 1.0.33
+appVersion: 1.0.34

--- a/_infra/helm/mock-eq/templates/externalsecrets.yaml
+++ b/_infra/helm/mock-eq/templates/externalsecrets.yaml
@@ -9,7 +9,7 @@ spec:
     name: gcp-secret-manager
     refreshInterval: 1m
   data:
-  - secretKey: json-secret-keys-mock-eq
+  - secretKey: mock-eq
     remoteRef:
-      key: mock-eq
+      key: json-secret-keys-mock-eq
       version: latest

--- a/_infra/helm/mock-eq/templates/externalsecrets.yaml
+++ b/_infra/helm/mock-eq/templates/externalsecrets.yaml
@@ -1,12 +1,15 @@
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ .Chart.Name }}
+  name: mock-eq
   namespace: {{ .Values.namespace }}
 spec:
-  backendType: gcpSecretsManager
-  projectId: {{ .Values.gcp.project }}
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: gcp-secret-manager
+    refreshInterval: 1m
   data:
-    - key: json-secret-keys-mock-eq
-      name: mock-eq
+  - secretKey: crypto-key
+    remoteRef:
+      key: mock-eq
       version: latest

--- a/_infra/helm/mock-eq/templates/externalsecrets.yaml
+++ b/_infra/helm/mock-eq/templates/externalsecrets.yaml
@@ -9,7 +9,7 @@ spec:
     name: gcp-secret-manager
     refreshInterval: 1m
   data:
-  - secretKey: crypto-key
+  - secretKey: json-secret-keys-mock-eq
     remoteRef:
       key: mock-eq
       version: latest


### PR DESCRIPTION
# What and why?
Changing ExternalSecret to use the cluster secret store pattern to facilitate migration to the External Secrets Operator and to align with other ExternalSecrets.

[See this PR for testing](https://github.com/ONSdigital/ras-rm-concourse/pull/218)
