### PR TITLE
Fix refreshInterval spec key indentation

### DIFF
--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
 
-version: 1.0.34
+version: 1.0.35
 
-appVersion: 1.0.34
+appVersion: 1.0.35

--- a/_infra/helm/mock-eq/templates/externalsecrets.yaml
+++ b/_infra/helm/mock-eq/templates/externalsecrets.yaml
@@ -7,7 +7,7 @@ spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: gcp-secret-manager
-    refreshInterval: 1m
+  refreshInterval: 1m
   data:
   - secretKey: mock-eq
     remoteRef:


### PR DESCRIPTION
# What and why?

refreshInterval for ExternalSecret was nested under the wrong key, its's a property of the spec.
