### PR TITLE
add checks for dependabot in GA workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,17 +42,19 @@ jobs:
       - name: Run tests
         run: make test
       - name: Authenticate with Google Cloud
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         id: auth
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - run: |
           gcloud auth configure-docker europe-west2-docker.pkg.dev
 
       - name: pr docker tag
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]'
         id: tag
         run: |
           PR=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
@@ -60,33 +62,37 @@ jobs:
           echo "pr_number=pr-$PR" >> $GITHUB_ENV
         # Build the Docker image
       - name: Build Docker Image
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }} -f _infra/docker/Dockerfile .
       - name: Push dev image
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }}
       - name: template helm
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           helm template $CHART_DIRECTORY
       - name: Set current tag
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]'
         id: vars
         run: |
           git fetch --tags
           echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
       - name: Import BOT GPG key
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: echo $BOT_GPG_KEY | base64 --decode | gpg --batch --import
         env:
           BOT_GPG_KEY: ${{ secrets.BOT_GPG_KEY }}
       - name: Prepare gpg CLI signing step
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           rm -rf /tmp/gpg.sh
           echo '#!/bin/bash' >> /tmp/gpg.sh
           echo 'gpg --batch --pinentry-mode=loopback --passphrase $BOT_GPG_KEY_PASSPHRASE $@' >> /tmp/gpg.sh
           chmod +x /tmp/gpg.sh
       - name: Setup git
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           git config commit.gpgsign true
           git config user.signingkey "${{ secrets.BOT_GPG_KEY_ID }}"
@@ -94,7 +100,7 @@ jobs:
           git config user.name "${{ secrets.BOT_USERNAME }}"
           git config user.email "${{ secrets.BOT_EMAIL }}"
       - name: update versions
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           BOT_GPG_KEY_PASSPHRASE: ${{ secrets.BOT_GPG_KEY_PASSPHRASE }}
@@ -155,13 +161,14 @@ jobs:
           echo "version=$(grep -E "appVersion:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')" >> $GITHUB_ENV
 
       - name: package helm
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo HELM_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g') >> $GITHUB_ENV
           helm dep up $CHART_DIRECTORY
           helm package $CHART_DIRECTORY
 
       - name: Publish dev Chart
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-${{ env.pr_number }}.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/


### PR DESCRIPTION
# What and why?
Adding dependabot-specific workflow for GA build. Whenever dependabot creates a PR, it will get to the tests before skipping the remaining steps and passing.

# How to test?

# Jira
[Card](https://jira.ons.gov.uk/browse/RAS-1566)