### PR TITLE
add bot commit steps to dependabot workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,25 +74,22 @@ jobs:
         run: |
           helm template $CHART_DIRECTORY
       - name: Set current tag
-        if: github.ref != 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]'
+        if: github.ref != 'refs/heads/main'
         id: vars
         run: |
           git fetch --tags
           echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
       - name: Import BOT GPG key
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: echo $BOT_GPG_KEY | base64 --decode | gpg --batch --import
         env:
           BOT_GPG_KEY: ${{ secrets.BOT_GPG_KEY }}
       - name: Prepare gpg CLI signing step
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           rm -rf /tmp/gpg.sh
           echo '#!/bin/bash' >> /tmp/gpg.sh
           echo 'gpg --batch --pinentry-mode=loopback --passphrase $BOT_GPG_KEY_PASSPHRASE $@' >> /tmp/gpg.sh
           chmod +x /tmp/gpg.sh
       - name: Setup git
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           git config commit.gpgsign true
           git config user.signingkey "${{ secrets.BOT_GPG_KEY_ID }}"
@@ -100,7 +97,7 @@ jobs:
           git config user.name "${{ secrets.BOT_USERNAME }}"
           git config user.email "${{ secrets.BOT_EMAIL }}"
       - name: update versions
-        if: github.ref != 'refs/heads/main' && github.event.pull_request.user.login != 'dependabot[bot]'
+        if: github.ref != 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           BOT_GPG_KEY_PASSPHRASE: ${{ secrets.BOT_GPG_KEY_PASSPHRASE }}

--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
-version: 1.0.38
+version: 1.0.39
 
-appVersion: 1.0.38
+appVersion: 1.0.39


### PR DESCRIPTION
# What and why?
Upon merging the recent dependabot GA workflow changes, it was discovered that the dependabot workflow does not kick off the bot commit to update the service's version number. This PR fixes this by removing some of the dependabot checks so that those steps are also run as part of a dependabot build. Additionally, the steps that involve signing the bot in were enabled for dependabot, since if these steps aren't run, the bot commit won't be verified, and the dependabot PR won't be able to be merged in after being approved.

# How to test?
You can't test this. Just look over the changes and make sure they're okay. Also, make sure that dependabot has access to all of the secret variables needed for the re-added steps ([see here](https://github.com/ONSdigital/ras-rm-mock-eq/settings/secrets/dependabot)).

# Jira
[Card](https://officefornationalstatistics.atlassian.net/jira/software/c/projects/RAS/boards/1943?isEligibleForUserSurvey=true&selectedIssue=RAS-1566)