### PR TITLE
Bump appVersion due to clash

### DIFF
--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
-version: 2.0.1
+version: 2.0.2
 
-appVersion: 2.0.1
+appVersion: 2.0.2


### PR DESCRIPTION
# What and why?

App Version clash following merge to main, so bumping manually.
