### PR TITLE
RAS-1919 Build new staging environment

### DIFF
--- a/_infra/helm/mock-eq/Chart.yaml
+++ b/_infra/helm/mock-eq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: mock-eq
 description: A Helm chart for Kubernetes
-version: 2.0.3
+version: 2.0.4
 
-appVersion: 2.0.3
+appVersion: 2.0.4

--- a/_infra/helm/mock-eq/templates/deployment.yaml
+++ b/_infra/helm/mock-eq/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
           value: "{{ .Values.gcp.project }}"
         - name: PUBSUB_TOPIC
           value: "{{ .Values.gcp.topic }}"
+        - name: FRONTSTAGE_URL
+          value: "{{ .Values.frontstageUrl }}"
         readinessProbe:
           httpGet:
             path: /info

--- a/_infra/helm/mock-eq/templates/ingress.yaml
+++ b/_infra/helm/mock-eq/templates/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}-ingress
   annotations:
     kubernetes.io/ingress.global-static-ip-name: mock-eq-ip
+    kubernetes.io/ingress.class: "gce"
     networking.gke.io/managed-certificates: {{ .Values.ingress.certNameMockEq }}
     networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfigName }}
 

--- a/_infra/helm/mock-eq/values.yaml
+++ b/_infra/helm/mock-eq/values.yaml
@@ -5,6 +5,8 @@ gcp:
   project: ras-rm-dev
   topic: sdx-receipt-dev
 
+frontstageUrl: https://localhost:8082/surveys/todo
+
 image:
   devRepo: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images
   name: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ras-rm-mock-eq"
-version = "2.0.3"
+version = "2.0.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ras-rm-mock-eq"
-version = "2.0.2"
+version = "2.0.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -593,7 +593,7 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "protobuf", marker = "python_full_version < '3.13'" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/fc/e9a65cd52c1330d8d23af6013651a0bc50b6d76bcbdf91fae7cd19c68f29/proto-plus-1.24.0.tar.gz", hash = "sha256:30b72a5ecafe4406b0d339db35b56c4059064e69227b8c3bda7462397f966445", size = 55942, upload-time = "2024-06-19T15:02:44.501Z" }
 wheels = [
@@ -609,7 +609,7 @@ resolution-markers = [
     "python_full_version == '3.13.*'",
 ]
 dependencies = [
-    { name = "protobuf", marker = "python_full_version >= '3.13'" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142, upload-time = "2025-03-10T15:54:38.843Z" }
 wheels = [
@@ -715,7 +715,7 @@ wheels = [
 
 [[package]]
 name = "ras-rm-mock-eq"
-version = "2.0.2"
+version = "2.0.3"
 source = { virtual = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
# What and why?
A couple updates to allow the ingress to create the required resources (loadbalancer) and adding the frontstage url as an environment variables to override the app config when in staging to redirect to the correct url
# How to test?
Follow https://github.com/ONSdigital/ras-rm-terraform/pull/491
Edit the ingress helm chart to contain the new annotation
Edit the deployment helm chart to contain the new frontstage url variable
# Jira
[RAS-1919](https://officefornationalstatistics.atlassian.net/browse/RAS-1919)

[RAS-1919]: https://officefornationalstatistics.atlassian.net/browse/RAS-1919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ